### PR TITLE
layout fix for paragraph renderer

### DIFF
--- a/renderers/renderer.paragraph.js
+++ b/renderers/renderer.paragraph.js
@@ -38,7 +38,7 @@
             version: "1.0",
             requires: [],
             defaults: {
-		'width': 'span12',
+		'width': '940',
 		'data': '',
 		'title_color': 'black',
 		'header_color': 'black',


### PR DESCRIPTION
The paragraph renderer was by default setting float: left, which made things flow into each other. This was fixed.
